### PR TITLE
use "==" instead of "!==" in "main.js" 

### DIFF
--- a/helloWorld/main.js
+++ b/helloWorld/main.js
@@ -28,7 +28,7 @@ app.on('ready', createWindow);
 
 
 app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') {
+  if (process.platform == 'darwin') {
     app.quit();
   }
 });


### PR DESCRIPTION
I think you have to use "==" instead of "!==" in "main.js" of "hello-world" project to entirely close the application if the operating system is darwin and all of the windows are closed!
![61525606-ff995580-aa2d-11e9-83a8-4ac5ad5b722e](https://user-images.githubusercontent.com/35492414/65980460-be2e1900-e466-11e9-87f7-ebc6a8963cc7.jpg)
